### PR TITLE
Fixes issue #15. Overwrite files in tempdir()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tabulizer
 Type: Package
 Title: Bindings for Tabula PDF Table Extractor Library
-Version: 0.1.22
+Version: 0.1.23
 Authors@R: c(person("Thomas J.", "Leeper", role = c("aut", "cre"),
                     email = "thosjleeper@gmail.com"),
              person("David", "Gohel", role = "ctb",

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,7 +10,11 @@ localize_file <- function(path, copy = FALSE, quiet = TRUE) {
     } else {
         if (copy) {
             tmp <- file.path(tempdir(), paste0(basename(file_path_sans_ext(path.expand(path))), ".pdf"))
-            file.copy(from = path.expand(path), to = tmp)
+            if (file.exists(tmp)){
+              message("There is already a file with this name in the temporary directory. It will be overwritten.")
+            }
+            file_to <- path.expand(path)
+            if (file_to != tmp) file.copy(from = file_to, to = tmp, overwrite = TRUE)
             path <- tmp
         } else {
             path <- path.expand(path)


### PR DESCRIPTION
I ran the tests and everything is clean. Note that a message and not a warning will be generated. Moreover, the message will always be generated. The `quiet` parameter is ignored. As this isn't an exported function and the behavior is potentially destructive, I thought it prudent to inform the user as default behavior.