### PR TITLE
`extract_tables()` in example code update to v0.2.0

### DIFF
--- a/R/extract_tables.R
+++ b/R/extract_tables.R
@@ -44,7 +44,7 @@
 #' extract_tables(f, pages = 2, area = list(c(126, 284, 174, 417)))
 #' 
 #' # return data.frames
-#' extract_tables(f, pages = 2, method = "data.frame")
+#' extract_tables(f, pages = 2, output = "data.frame")
 #' }
 #' @seealso \code{\link{extract_areas}}, \code{\link{get_page_dims}}, \code{\link{make_thumbnails}}, \code{\link{split_pdf}}
 #' @import tabulizerjars

--- a/man/extract_tables.Rd
+++ b/man/extract_tables.Rd
@@ -68,7 +68,7 @@ extract_tables(f, pages = 2, area = list(c(126, 149, 212, 462)))
 extract_tables(f, pages = 2, area = list(c(126, 284, 174, 417)))
 
 # return data.frames
-extract_tables(f, pages = 2, method = "data.frame")
+extract_tables(f, pages = 2, output = "data.frame")
 }
 }
 \references{


### PR DESCRIPTION
I just found example code typo.

Changed `method = "data.frame"` to a new argument name (`output = "data.frame"`) because `method` changed to an argument with [another feature](https://github.com/ropensci/tabulizer/commit/9d4043515126f1848b926442c337aa3b04f678dd#diff-8312ad0561ef661716b48d09478362f3R5).

---

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/responserates/issues/new) first... ***NOT APPLICABLE***
 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/responserates/blob/master/DESCRIPTION)... ***NOT APPLICABLE***
 - [x] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/responserates/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed... ***NOT APPLICABLE***
 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/responserates/tree/master/tests/testthat) for any new functionality or bug fix... ***NOT APPLICABLE***
 - [x] make sure `R CMD check` runs without error before submitting the PR

